### PR TITLE
Remove redundant OpenCV headers

### DIFF
--- a/ComponentRealSenseV2Server/smartsoft/src/ImageTask.cc
+++ b/ComponentRealSenseV2Server/smartsoft/src/ImageTask.cc
@@ -49,7 +49,6 @@
 #include "ImageTask.hh"
 #include "ComponentRealSenseV2Server.hh"
 #include "EulerTransformationMatrices.hh"
-#include <opencv2/opencv.hpp>
 
 
 #include <sstream>

--- a/ComponentRealSenseV2Server/smartsoft/src/RealSenSeWrapper.cc
+++ b/ComponentRealSenseV2Server/smartsoft/src/RealSenSeWrapper.cc
@@ -47,7 +47,6 @@
 //
 //--------------------------------------------------------------------------
 #include "RealSenSeWrapper.hh"
-#include <opencv2/opencv.hpp>
 #include <librealsense2/h/rs_pipeline.h>
 #include <librealsense2/rsutil.h>
 #define TEXT_COLOR_RESET   "\033[0m"


### PR DESCRIPTION
Unused, but was causing linker errors for some reason.