### PR TITLE
Adjust camera start/stop capture commands to lifetime of RS handle

### DIFF
--- a/ComponentRealSenseV2Server/smartsoft/src/ImageTask.cc
+++ b/ComponentRealSenseV2Server/smartsoft/src/ImageTask.cc
@@ -78,30 +78,6 @@ ImageTask::~ImageTask()
 	_ring_buffer.clear();
 }
 
-void ImageTask::startCapturing() {
-	SmartACE::SmartGuard(COMP->RealSenseMutex);
-	if (COMP->smart_rs_device != NULL) {
-		COMP->smart_rs_device->startVideo();
-
-	}
-	if (COMP->getGlobalState().getSettings().getDebug_info()) {
-		std::cout << "[Image Task] Start capturing\n";
-	}
-}
-
-void ImageTask::stopCapturing() {
-	SmartACE::SmartGuard guard(COMP->RealSenseMutex);
-	if (COMP->smart_rs_device != NULL) {
-			COMP->smart_rs_device->stopVideo();
-	}
-
-	if (COMP->getGlobalState().getSettings().getDebug_info()) {
-		std::cout << "[Image Task] Stop capturing\n";
-	}
-}
-
-
-
 int ImageTask::on_entry()
 {
 	ParameterStateStruct global_state = COMP->getGlobalState();
@@ -146,6 +122,11 @@ int ImageTask::on_entry()
 				                                 device_serial_number, base_line);
 
 	COMP->smart_rs_device->set_is_postprocess_enabled(global_state.getSettings().getPost_processing());
+	COMP->smart_rs_device->startVideo();
+
+	if (COMP->getGlobalState().getSettings().getDebug_info()) {
+		std::cout << "[Image Task] Start capturing\n";
+	}
 
 	return 0;
 }
@@ -310,5 +291,15 @@ int ImageTask::on_execute()
 int ImageTask::on_exit()
 {
 	// use this method to clean-up resources which are initialized in on_entry() and needs to be freed before the on_execute() can be called again
+	SmartACE::SmartGuard guard(COMP->RealSenseMutex);
+	COMP->smart_rs_device->stopVideo();
+
+	if (COMP->getGlobalState().getSettings().getDebug_info()) {
+		std::cout << "[Image Task] Stop capturing\n";
+	}
+
+	delete COMP->smart_rs_device;
+	COMP->smart_rs_device = NULL;
+
 	return 0;
 }

--- a/ComponentRealSenseV2Server/smartsoft/src/ImageTask.hh
+++ b/ComponentRealSenseV2Server/smartsoft/src/ImageTask.hh
@@ -65,8 +65,6 @@ public:
 	virtual int on_execute();
 	virtual int on_exit();
 
-	void startCapturing();
-	void stopCapturing();
 	bool push_newest_rgbd;
 	bool push_newest_rgb;
 	bool push_newest_depth;

--- a/ComponentRealSenseV2Server/smartsoft/src/SmartStateChangeHandler.cc
+++ b/ComponentRealSenseV2Server/smartsoft/src/SmartStateChangeHandler.cc
@@ -55,27 +55,10 @@
 void SmartStateChangeHandler::handleEnterState(const std::string & substate) throw()
 {
 	std::cout<<"handleEnterState: "<<substate<<std::endl;
-		if (substate == "nonneutral") {
-			COMP->imageTask->startCapturing();
-		}
-		if (substate == "pushimage"){
-			//COMP->colorImagePushNewestServer->start();
-			//std::cout << "Push Newest started.\n";
-		}
-
 }
 
 // Called when a substate is left
 void SmartStateChangeHandler::handleQuitState(const std::string & substate) throw()
 {
 	std::cout<<"handleQuitState: "<<substate<<std::endl;
-	if (substate == "nonneutral") {
-		COMP->imageTask->stopCapturing();
-	}
-
-	if (substate == "pushimage"){
-		//COMP->colorImagePushNewestServer->stop();
-		//std::cout << "Push Timed stopped.\n";
-	}
-
 }


### PR DESCRIPTION
Capturing commands were subject to substate mode changes, whereas the lifetime of the RS object instance is tightly bound to the activity thread. This is not a problem in case the component is started in *Neutral* state and commanded to switch later to *PushState* as memory has been properly allocated at that time. However, doing so on component init (i.e. with `<initialcomponentmode>` parameter equal to *PushState*) causes the pipeline to attempt an early start. It fails since the thread is not created yet and, consequently, `COMP->smart_rs_device` is `NULL`. On each loop, fresh frames are requested from the device, but the RS framework complains about the pipeline not being properly started.

This commit defers initial pipeline start, decoupling it from state changes. Since `COMP->smart_rs_device` lives for as long as
the thread does its job, pipeline start and stop capture commands are now bound to thread start and stop, respectively. Also,
allocated dynamic memory is now properly destroyed on thread stop.